### PR TITLE
Fixing wait command to exit if any daemon dies

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -29,7 +29,7 @@ function shutdown() {
 
 # run shutdown
 trap shutdown SIGINT
-wait
+wait -n
 
 # return received result
 exit $latest_exit


### PR DESCRIPTION
Adding the `-n` flag will close the container if either `freshclam` or `clamd` exits.  I ran into a problem with clamd died for some reason, but the container kept running.