### PR TITLE
Add http proxy env support for freshclam

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,8 +3,6 @@ LABEL maintainer="Markus Kosmal <dude@m-ko.de> https://m-ko.de"
 
 # Debian Base to use
 ENV DEBIAN_VERSION stretch
-ENV HTTPProxyServer <HTTPProxyServer>
-ENV HTTPProxyPort <HTTPProxyPort>
 
 # initial install of av daemon
 RUN echo "deb http://http.debian.net/debian/ $DEBIAN_VERSION main contrib non-free" > /etc/apt/sources.list && \
@@ -33,8 +31,8 @@ RUN mkdir /var/run/clamav && \
 # av configuration update
 RUN sed -i 's/^Foreground .*$/Foreground true/g' /etc/clamav/clamd.conf && \
     echo "TCPSocket 3310" >> /etc/clamav/clamd.conf && \
-    echo "HTTPProxyServer $HTTPProxyServer" >> /etc/clamav/freshclam.conf && \
-    echo "HTTPProxyPort $HTTPProxyPort" >> /etc/clamav/freshclam.conf && \
+    if ! [ -z $HTTPProxyServer ]; then echo "HTTPProxyServer $HTTPProxyServer" >> /etc/clamav/freshclam.conf; fi && \
+    if ! [ -z $HTTPProxyPort   ]; then echo "HTTPProxyPort $HTTPProxyPort" >> /etc/clamav/freshclam.conf; fi && \
     sed -i 's/^Foreground .*$/Foreground true/g' /etc/clamav/freshclam.conf
 
 # volume provision

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,8 @@ LABEL maintainer="Markus Kosmal <dude@m-ko.de> https://m-ko.de"
 
 # Debian Base to use
 ENV DEBIAN_VERSION stretch
+ENV HTTPProxyServer <HTTPProxyServer>
+ENV HTTPProxyPort <HTTPProxyPort>
 
 # initial install of av daemon
 RUN echo "deb http://http.debian.net/debian/ $DEBIAN_VERSION main contrib non-free" > /etc/apt/sources.list && \
@@ -31,6 +33,8 @@ RUN mkdir /var/run/clamav && \
 # av configuration update
 RUN sed -i 's/^Foreground .*$/Foreground true/g' /etc/clamav/clamd.conf && \
     echo "TCPSocket 3310" >> /etc/clamav/clamd.conf && \
+    echo "HTTPProxyServer $HTTPProxyServer" >> /etc/clamav/freshclam.conf && \
+    echo "HTTPProxyPort $HTTPProxyPort" >> /etc/clamav/freshclam.conf && \
     sed -i 's/^Foreground .*$/Foreground true/g' /etc/clamav/freshclam.conf
 
 # volume provision


### PR DESCRIPTION
Now we can update clamav definitions over corporative proxy server, using the HTTPProxyServer and HTTPProxyPort container environments.

Example usage: `docker run -d -p 3310:3310 mk0x/docker-clamav -e HTTPProxyServer=proxy.corp.local -e HTTPProxyPort=3128`

This strings if defined will be added to /etc/clamav/freshclam.conf file.