### PR TITLE
Use Debian Buster

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
-FROM debian:stretch-slim
+FROM debian:buster-slim
 LABEL maintainer="Markus Kosmal <dude@m-ko.de> https://m-ko.de"
 
 # Debian Base to use
-ENV DEBIAN_VERSION stretch
+ENV DEBIAN_VERSION buster
 
 # initial install of av daemon
 RUN echo "deb http://http.debian.net/debian/ $DEBIAN_VERSION main contrib non-free" > /etc/apt/sources.list && \
@@ -12,7 +12,7 @@ RUN echo "deb http://http.debian.net/debian/ $DEBIAN_VERSION main contrib non-fr
     DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends -y -qq \
         clamav-daemon \
         clamav-freshclam \
-        libclamunrar7 \
+        libclamunrar9 \
         wget && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Find the latest releases at the official [docker hub](https://hub.docker.com/r/m
 
 ## Usage
 
-### Debian Stretch Slim (default, :latest, :stretch-slim)
+### Debian Buster Slim (default, :latest, :buster-slim)
 ```bash
     docker run -d -p 3310:3310 mk0x/docker-clamav
 ```


### PR DESCRIPTION
The clamav-daemon package in Debian Buster is the latest version, so we avoid outdated warnings at startup.

This PR updates the Dockerfile so it uses debian:buster-slim instead of debian:stretch-slim.