### PR TITLE
Allow clamd.conf and freshclam.conf to have entries replaced or appended by env variables with CLAMD_CONF_ and FRESHCLAM_CONF_ prefixes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -35,6 +35,9 @@ RUN sed -i 's/^Foreground .*$/Foreground true/g' /etc/clamav/clamd.conf && \
     if ! [ -z $HTTPProxyPort   ]; then echo "HTTPProxyPort $HTTPProxyPort" >> /etc/clamav/freshclam.conf; fi && \
     sed -i 's/^Foreground .*$/Foreground true/g' /etc/clamav/freshclam.conf
 
+# env based configs - will be called by bootstrap.sh
+ADD envconfig.sh /
+
 # volume provision
 VOLUME ["/var/lib/clamav"]
 

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -3,6 +3,9 @@
 # presented by mko (Markus Kosmal<dude@m-ko.de>)
 set -m
 
+# configure freshclam.conf and clamd.conf from env variables if present
+source /envconfig.sh
+
 # start clam service itself and the updater in background as daemon
 freshclam -d &
 clamd &

--- a/envconfig.sh
+++ b/envconfig.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+# update clamd.conf and freshclam.conf from env variables
+
+for OUTPUT in $(env | awk -F "=" '{print $1}' | grep "^CLAMD_CONF_")
+do
+	TRIMMED=$(echo $OUTPUT | sed 's/CLAMD_CONF_//g')
+	grep -q "^$TRIMMED " /etc/clamav/clamd.conf && sed "s/^$TRIMMED .*/$TRIMMED ${!OUTPUT}/" -i /etc/clamav/clamd.conf ||
+	    sed "$ a\\$TRIMMED ${!OUTPUT}" -i /etc/clamav/clamd.conf
+done
+
+for OUTPUT in $(env | awk -F "=" '{print $1}' | grep "^FRESHCLAM_CONF_")
+do
+	TRIMMED=$(echo $OUTPUT | sed 's/FRESHCLAM_CONF_//g')
+	grep -q "^$TRIMMED " /etc/clamav/freshclam.conf && sed "s/^$TRIMMED .*/$TRIMMED ${!OUTPUT}/" -i /etc/clamav/freshclam.conf ||
+	    sed "$ a\\$TRIMMED ${!OUTPUT}" -i /etc/clamav/freshclam.conf
+done


### PR DESCRIPTION
This should resolve #29 and allow greater configuration flexibility in general

As an example, passing CLAMD_CONF_MaxScanSize 500M will replace the MaxScanSize entry in /etc/clamav/clamd.conf with 500M

The same applies to freshclam.conf with the FRESHCLAM_CONF_ prefix

If a configuration entry doesn't exist it will be appended at the end of the file.

This also relies on #30 to be merged to build successfully, as libclamunrar7 is no longer available