### PR TITLE
Remove DetectBrokenExecutables as it is deprecated

### DIFF
--- a/conf/clamd.conf
+++ b/conf/clamd.conf
@@ -27,7 +27,6 @@ Bytecode yes
 ScanPE yes
 DisableCertCheck yes
 ScanELF yes
-DetectBrokenExecutables yes
 ScanOLE2 yes
 ScanPDF yes
 ScanSWF yes


### PR DESCRIPTION
I continually run into this message when I run clamscan or freshclam:

```
WARNING: Ignoring deprecated option DetectBrokenExecutables at /etc/clamav/clamd.conf:30
```

Usually I run a `sed` command to remove the line but it would be easier if it wasn't packaged at all. 