### PR TITLE
Freshclam mirror config

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -35,6 +35,8 @@ RUN sed -i 's/^Foreground .*$/Foreground true/g' /etc/clamav/clamd.conf && \
     echo "TCPSocket 3310" >> /etc/clamav/clamd.conf && \
     if [ -n "$HTTPProxyServer" ]; then echo "HTTPProxyServer $HTTPProxyServer" >> /etc/clamav/freshclam.conf; fi && \
     if [ -n "$HTTPProxyPort"   ]; then echo "HTTPProxyPort $HTTPProxyPort" >> /etc/clamav/freshclam.conf; fi && \
+    if [ -n "$DatabaseMirror"  ]; then echo "DatabaseMirror $DatabaseMirror" >> /etc/clamav/freshclam.conf; fi && \
+    if [ -n "$DatabaseMirror"  ]; then echo "ScriptedUpdates off" >> /etc/clamav/freshclam.conf; fi && \
     sed -i 's/^Foreground .*$/Foreground true/g' /etc/clamav/freshclam.conf
 
 # env based configs - will be called by bootstrap.sh

--- a/README.md
+++ b/README.md
@@ -42,6 +42,10 @@ Thanks to @mchus proxy configuration is possible.
 - HTTPProxyServer: Allows to set a proxy server
 - HTTPProxyPort: Allows to set a proxy server port
 
+Specifying a particular mirror for freshclam is also possible.
+
+- DatabaseMirror: Hostname of the mirror web server.
+
 ## Releases
 Find the latest releases at the official [docker hub](https://hub.docker.com/r/mkodockx/docker-clamav) registry.
 


### PR DESCRIPTION
This allows an environment variable to set, which in turn sets the DatabaseMirror option in the freshclam config file.