### PR TITLE
Fix/permission fail on azure

### DIFF
--- a/alpine/edge/Dockerfile
+++ b/alpine/edge/Dockerfile
@@ -5,13 +5,16 @@ RUN apk add --no-cache bash clamav rsyslog wget clamav-libunrar
 
 COPY conf /etc/clamav
 COPY bootstrap.sh /
-COPY check.sh /check.sh
+COPY check.sh /
 
-RUN chmod u+x bootstrap.sh check.sh
+RUN mkdir /var/run/clamav && \
+    chown clamav:clamav /var/run/clamav && \
+    chmod 750 /var/run/clamav && \
+    chown -R clamav:clamav bootstrap.sh check.sh /etc/clamav && \
+    chmod u+x bootstrap.sh check.sh 
 
 EXPOSE 3310/tcp
 
-
-CMD ["/bootstrap.sh"]
+USER clamav
 
 HEALTHCHECK --start-period=500s CMD /check.sh

--- a/alpine/edge/Dockerfile
+++ b/alpine/edge/Dockerfile
@@ -17,4 +17,6 @@ EXPOSE 3310/tcp
 
 USER clamav
 
+CMD ["/bootstrap.sh"]
+
 HEALTHCHECK --start-period=500s CMD /check.sh

--- a/alpine/edge/Dockerfile.arm32v7
+++ b/alpine/edge/Dockerfile.arm32v7
@@ -17,13 +17,15 @@ COPY conf /etc/clamav
 COPY bootstrap.sh /
 COPY check.sh /
 
-RUN chmod u+x bootstrap.sh check.sh
 RUN mkdir /var/run/clamav && \
     chown clamav:clamav /var/run/clamav && \
-    chmod 750 /var/run/clamav
+    chmod 750 /var/run/clamav && \
+    chown -R clamav:clamav bootstrap.sh check.sh /etc/clamav && \
+    chmod u+x bootstrap.sh check.sh 
 
 EXPOSE 3310/tcp
 
+USER clamav
 
 CMD ["/bootstrap.sh"]
 

--- a/alpine/edge/Dockerfile.arm64v8
+++ b/alpine/edge/Dockerfile.arm64v8
@@ -17,13 +17,15 @@ COPY conf /etc/clamav
 COPY bootstrap.sh /
 COPY check.sh /
 
-RUN chmod u+x bootstrap.sh check.sh
 RUN mkdir /var/run/clamav && \
     chown clamav:clamav /var/run/clamav && \
-    chmod 750 /var/run/clamav
+    chmod 750 /var/run/clamav && \
+    chown -R clamav:clamav bootstrap.sh check.sh /etc/clamav && \
+    chmod u+x bootstrap.sh check.sh 
 
 EXPOSE 3310/tcp
 
+USER clamav
 
 CMD ["/bootstrap.sh"]
 

--- a/alpine/edge/conf/clamd.conf
+++ b/alpine/edge/conf/clamd.conf
@@ -5,7 +5,7 @@
 DatabaseDirectory /var/lib/clamav
 TemporaryDirectory /tmp
 LogTime yes
-PidFile /run/clamd.pid
+PidFile /run/clamav/clamd.pid
 LocalSocket /run/clamav/clamd.sock
 TCPSocket 3310
 Foreground yes

--- a/alpine/main/Dockerfile
+++ b/alpine/main/Dockerfile
@@ -7,12 +7,15 @@ COPY conf /etc/clamav
 COPY bootstrap.sh /
 COPY check.sh /
 
-RUN chmod u+x bootstrap.sh check.sh && mkdir /store
 RUN mkdir /var/run/clamav && \
     chown clamav:clamav /var/run/clamav && \
-    chmod 750 /var/run/clamav
+    chmod 750 /var/run/clamav && \
+    chown -R clamav:clamav bootstrap.sh check.sh /etc/clamav && \
+    chmod u+x bootstrap.sh check.sh 
 
 EXPOSE 3310/tcp
+
+USER clamav
 
 CMD ["/bootstrap.sh"]
 

--- a/alpine/main/Dockerfile.arm32v7
+++ b/alpine/main/Dockerfile.arm32v7
@@ -16,12 +16,15 @@ COPY conf /etc/clamav
 COPY bootstrap.sh /
 COPY check.sh /
 
-RUN chmod u+x bootstrap.sh check.sh
 RUN mkdir /var/run/clamav && \
     chown clamav:clamav /var/run/clamav && \
-    chmod 750 /var/run/clamav
+    chmod 750 /var/run/clamav && \
+    chown -R clamav:clamav bootstrap.sh check.sh /etc/clamav && \
+    chmod u+x bootstrap.sh check.sh 
 
 EXPOSE 3310/tcp
+
+USER clamav
 
 CMD ["/bootstrap.sh"]
 

--- a/alpine/main/Dockerfile.arm64v8
+++ b/alpine/main/Dockerfile.arm64v8
@@ -16,12 +16,15 @@ COPY conf /etc/clamav
 COPY bootstrap.sh /
 COPY check.sh /
 
-RUN chmod u+x bootstrap.sh check.sh
 RUN mkdir /var/run/clamav && \
     chown clamav:clamav /var/run/clamav && \
-    chmod 750 /var/run/clamav
+    chmod 750 /var/run/clamav && \
+    chown -R clamav:clamav bootstrap.sh check.sh /etc/clamav && \
+    chmod u+x bootstrap.sh check.sh 
 
 EXPOSE 3310/tcp
+
+USER clamav
 
 CMD ["/bootstrap.sh"]
 

--- a/alpine/main/conf/clam.conf
+++ b/alpine/main/conf/clam.conf
@@ -5,7 +5,7 @@
 DatabaseDirectory /var/lib/clamav
 TemporaryDirectory /tmp
 LogTime yes
-PidFile /run/clamd.pid
+PidFile /run/clamav/clamd.pid
 LocalSocket /run/clamav/clamd.sock
 TCPSocket 3310
 Foreground yes

--- a/debian/buster/Dockerfile
+++ b/debian/buster/Dockerfile
@@ -39,18 +39,19 @@ RUN sed -i 's/^Foreground .*$/Foreground true/g' /etc/clamav/clamd.conf && \
     if [ -n "$DatabaseMirror"  ]; then echo "ScriptedUpdates off" >> /etc/clamav/freshclam.conf; fi && \
     sed -i 's/^Foreground .*$/Foreground true/g' /etc/clamav/freshclam.conf
 
+
 # env based configs - will be called by bootstrap.sh
 COPY envconfig.sh /
 COPY check.sh /
 COPY bootstrap.sh /
 
-# volume provision
-
-
 # port provision
 EXPOSE 3310
 
-RUN chmod u+x bootstrap.sh check.sh envconfig.sh
+RUN chown clamav:clamav bootstrap.sh check.sh envconfig.sh && \
+    chmod u+x bootstrap.sh check.sh envconfig.sh    
+
+USER clamav
 
 CMD ["/bootstrap.sh"]
 

--- a/debian/buster/Dockerfile.arm32v7
+++ b/debian/buster/Dockerfile.arm32v7
@@ -53,13 +53,14 @@ COPY envconfig.sh /
 COPY check.sh /
 COPY bootstrap.sh /
 
-# volume provision
-
-
 # port provision
 EXPOSE 3310
 
-RUN chmod u+x bootstrap.sh check.sh envconfig.sh
+RUN chown clamav:clamav bootstrap.sh check.sh envconfig.sh && \
+    chmod u+x bootstrap.sh check.sh envconfig.sh 
+
+USER clamav
+
 CMD ["/bootstrap.sh"]
 
 HEALTHCHECK --start-period=500s CMD /check.sh

--- a/debian/buster/Dockerfile.arm64v8
+++ b/debian/buster/Dockerfile.arm64v8
@@ -53,13 +53,14 @@ COPY envconfig.sh /
 COPY check.sh /
 COPY bootstrap.sh /
 
-# volume provision
-
-
 # port provision
 EXPOSE 3310
 
-RUN chmod u+x bootstrap.sh check.sh envconfig.sh
+RUN chown clamav:clamav bootstrap.sh check.sh envconfig.sh && \
+    chmod u+x bootstrap.sh check.sh envconfig.sh 
+
+USER clamav
+
 CMD ["/bootstrap.sh"]
 
 HEALTHCHECK --start-period=500s CMD /check.sh

--- a/debian/stretch/Dockerfile
+++ b/debian/stretch/Dockerfile
@@ -35,14 +35,15 @@ RUN sed -i 's/^Foreground .*$/Foreground true/g' /etc/clamav/clamd.conf && \
     if ! [ -z $HTTPProxyPort   ]; then echo "HTTPProxyPort $HTTPProxyPort" >> /etc/clamav/freshclam.conf; fi && \
     sed -i 's/^Foreground .*$/Foreground true/g' /etc/clamav/freshclam.conf
 
-# volume provision
-
-
 # port provision
 EXPOSE 3310
 
-# av daemon bootstrapping
-ADD bootstrap.sh /
-RUN chmod u+x bootstrap.sh
+COPY bootstrap.sh /
+RUN chown clamav:clamav bootstrap.sh && \
+    chmod u+x bootstrap.sh
+
+USER clamav
 
 CMD ["/bootstrap.sh"]
+
+HEALTHCHECK --start-period=500s CMD /check.sh

--- a/debian/stretch/Dockerfile.arm32v7
+++ b/debian/stretch/Dockerfile.arm32v7
@@ -44,14 +44,15 @@ RUN sed -i 's/^Foreground .*$/Foreground true/g' /etc/clamav/clamd.conf && \
     if ! [ -z $HTTPProxyPort   ]; then echo "HTTPProxyPort $HTTPProxyPort" >> /etc/clamav/freshclam.conf; fi && \
     sed -i 's/^Foreground .*$/Foreground true/g' /etc/clamav/freshclam.conf
 
-# volume provision
-
-
 # port provision
 EXPOSE 3310
 
-# av daemon bootstrapping
-ADD bootstrap.sh /
-RUN chmod u+x bootstrap.sh
+COPY bootstrap.sh /
+RUN chown clamav:clamav bootstrap.sh && \
+    chmod u+x bootstrap.sh
+
+USER clamav
 
 CMD ["/bootstrap.sh"]
+
+HEALTHCHECK --start-period=500s CMD /check.sh

--- a/debian/stretch/Dockerfile.arm64v8
+++ b/debian/stretch/Dockerfile.arm64v8
@@ -44,14 +44,15 @@ RUN sed -i 's/^Foreground .*$/Foreground true/g' /etc/clamav/clamd.conf && \
     if ! [ -z $HTTPProxyPort   ]; then echo "HTTPProxyPort $HTTPProxyPort" >> /etc/clamav/freshclam.conf; fi && \
     sed -i 's/^Foreground .*$/Foreground true/g' /etc/clamav/freshclam.conf
 
-# volume provision
-
-
 # port provision
 EXPOSE 3310
 
-# av daemon bootstrapping
-ADD bootstrap.sh /
-RUN chmod u+x bootstrap.sh
+COPY bootstrap.sh /
+RUN chown clamav:clamav bootstrap.sh && \
+    chmod u+x bootstrap.sh 
+
+USER clamav
 
 CMD ["/bootstrap.sh"]
+
+HEALTHCHECK --start-period=500s CMD /check.sh


### PR DESCRIPTION
Solves #78.

I can only assume what the problem was: `/var/run/clamav` was set to be owned by user `clamav`, yet the container user was `root`. This seems to be local not a problem, but cloud provider tend to give you only some kind of "fake root". So I made sure files and directories used by the clamav apps have the right permissions for user `clamav` and let the container run with this user