### PR TITLE
Remove healthcheck from dockerfile

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,23 @@ See example with Nextcloud at [docker-compose.yml](https://github.com/mko-x/dock
 
 You can find a tutorial here: https://www.virtualconfusion.net/clamav-for-nextcloud-on-docker/
 
+## Healthcheck
+The images provide with `check.sh` a file to check for the healthyness of the running container. To enable the health check configure your `docker run` or `compose file`. The _start period_ should be adjusted to your system needs. Slow internet connection, with limited cpu and IO speed might require larger values.
+
+### docker run
+`docker run --health-cmd=./check.sh --health-start-period=120s --health-interval=60s --health-retries=3 -p 3310:3310 mkodockx/docker-clamav:alpine`
+
+### compose
+```yml
+  services:
+    clamav:
+      healthcheck:
+        test: ["CMD", "./check.sh"]
+        interval: 60s
+        retries: 3
+        start_period: 120s
+```
+
 # Build multi-arch
 This image provides support for different platforms 
 - x86

--- a/alpine/edge/Dockerfile
+++ b/alpine/edge/Dockerfile
@@ -18,5 +18,3 @@ EXPOSE 3310/tcp
 USER clamav
 
 CMD ["/bootstrap.sh"]
-
-HEALTHCHECK --start-period=500s CMD /check.sh

--- a/alpine/edge/Dockerfile.arm32v7
+++ b/alpine/edge/Dockerfile.arm32v7
@@ -28,5 +28,3 @@ EXPOSE 3310/tcp
 USER clamav
 
 CMD ["/bootstrap.sh"]
-
-HEALTHCHECK --start-period=500s CMD /check.sh

--- a/alpine/edge/Dockerfile.arm64v8
+++ b/alpine/edge/Dockerfile.arm64v8
@@ -28,5 +28,3 @@ EXPOSE 3310/tcp
 USER clamav
 
 CMD ["/bootstrap.sh"]
-
-HEALTHCHECK --start-period=500s CMD /check.sh

--- a/alpine/main/Dockerfile
+++ b/alpine/main/Dockerfile
@@ -18,5 +18,3 @@ EXPOSE 3310/tcp
 USER clamav
 
 CMD ["/bootstrap.sh"]
-
-HEALTHCHECK --start-period=120s CMD /check.sh

--- a/alpine/main/Dockerfile.arm32v7
+++ b/alpine/main/Dockerfile.arm32v7
@@ -27,5 +27,3 @@ EXPOSE 3310/tcp
 USER clamav
 
 CMD ["/bootstrap.sh"]
-
-HEALTHCHECK --start-period=120s CMD /check.sh

--- a/alpine/main/Dockerfile.arm64v8
+++ b/alpine/main/Dockerfile.arm64v8
@@ -27,5 +27,3 @@ EXPOSE 3310/tcp
 USER clamav
 
 CMD ["/bootstrap.sh"]
-
-HEALTHCHECK --start-period=120s CMD /check.sh

--- a/debian/buster/Dockerfile
+++ b/debian/buster/Dockerfile
@@ -54,5 +54,3 @@ RUN chown clamav:clamav bootstrap.sh check.sh envconfig.sh && \
 USER clamav
 
 CMD ["/bootstrap.sh"]
-
-HEALTHCHECK --start-period=500s CMD /check.sh

--- a/debian/buster/Dockerfile.arm32v7
+++ b/debian/buster/Dockerfile.arm32v7
@@ -62,5 +62,3 @@ RUN chown clamav:clamav bootstrap.sh check.sh envconfig.sh && \
 USER clamav
 
 CMD ["/bootstrap.sh"]
-
-HEALTHCHECK --start-period=500s CMD /check.sh

--- a/debian/buster/Dockerfile.arm64v8
+++ b/debian/buster/Dockerfile.arm64v8
@@ -62,5 +62,3 @@ RUN chown clamav:clamav bootstrap.sh check.sh envconfig.sh && \
 USER clamav
 
 CMD ["/bootstrap.sh"]
-
-HEALTHCHECK --start-period=500s CMD /check.sh

--- a/debian/stretch/Dockerfile
+++ b/debian/stretch/Dockerfile
@@ -39,11 +39,10 @@ RUN sed -i 's/^Foreground .*$/Foreground true/g' /etc/clamav/clamd.conf && \
 EXPOSE 3310
 
 COPY bootstrap.sh /
-RUN chown clamav:clamav bootstrap.sh && \
-    chmod u+x bootstrap.sh
+COPY check.sh /
+RUN chown clamav:clamav bootstrap.sh check.sh && \
+    chmod u+x bootstrap.sh check.sh
 
 USER clamav
 
 CMD ["/bootstrap.sh"]
-
-HEALTHCHECK --start-period=500s CMD /check.sh

--- a/debian/stretch/Dockerfile.arm32v7
+++ b/debian/stretch/Dockerfile.arm32v7
@@ -54,5 +54,3 @@ RUN chown clamav:clamav bootstrap.sh && \
 USER clamav
 
 CMD ["/bootstrap.sh"]
-
-HEALTHCHECK --start-period=500s CMD /check.sh

--- a/debian/stretch/Dockerfile.arm64v8
+++ b/debian/stretch/Dockerfile.arm64v8
@@ -54,5 +54,3 @@ RUN chown clamav:clamav bootstrap.sh && \
 USER clamav
 
 CMD ["/bootstrap.sh"]
-
-HEALTHCHECK --start-period=500s CMD /check.sh

--- a/debian/stretch/check.sh
+++ b/debian/stretch/check.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+
+if [ "$(echo PING | nc localhost 3310)" = "PONG" ]; then
+    echo "ping successful"
+else
+    echo 1>&2 "ping failed"
+    exit 1
+fi


### PR DESCRIPTION
 Closes #83
I ended up removing the health check from the image. Finding a good value depdends on the HW one has available. For me even 90s would be enough (starting alpine, downloading definitions, starting clam). To encurage the use of the health check I added documentation for it.