### PR TITLE
Add possibility to use own .conf files

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,14 +16,16 @@ is listening on exposed port `3310`.
 Find the latest releases at the official [docker hub](https://hub.docker.com/r/mkodockx/docker-clamav) registry. There are different releases for the different platforms.
 
 # Usage
-### Debian (default, :latest, :buster-slim, :stretch-slim)
+The container run as user `clamav` with `uid=101` and `gid=102`.
+
+## Debian (default, :latest, :buster-slim, :stretch-slim)
 - buster-slim
 - stretch-slim
 ```bash
     docker run -d -p 3310:3310 mkodockx/docker-clamav:buster-slim
 ```
 
-### Alpine (:alpine, :alpine-edge)
+## Alpine (:alpine, :alpine-edge)
 - alpine
 - alpine-edge
 ```bash
@@ -44,6 +46,12 @@ Thanks to @mchus proxy configuration is possible.
 
 Specifying a particular mirror for freshclam is also possible.
 - DatabaseMirror: Hostname of the mirror web server.
+
+### FRESHCLAM_CONF_FILE
+Set the path to a custom `freshclam.conf` file, e.g. `/mnt/myfreshclam.conf`. The file needs to be mounted.
+
+### CLAMD_CONF_FILE
+Set the path to a custom `clam.conf` file, e.g. `/mnt/myclam.conf`. The file needs to be mounted.
 
 ## Persistency
 Virus update definitions are stored in `/var/lib/clamav`. To store the defintion just mount the directory as a volume, `docker run -d -p 3310:3310 -v ./clamav:/var/lib/clamav mkodockx/docker-clamav:latest`

--- a/alpine/edge/bootstrap.sh
+++ b/alpine/edge/bootstrap.sh
@@ -1,6 +1,17 @@
 #!/bin/bash
+set -e
 
-set -eu
+if [[ ! -z "${FRESHCLAM_CONF_FILE}" ]]; then
+    echo "[bootstrap] FRESHCLAM_CONF_FILE set, copy to /etc/clamav/freshclam.conf"
+    mv /etc/clamav/freshclam.conf /etc/clamav/freshclam.conf.bak
+    cp -f ${FRESHCLAM_CONF_FILE} /etc/clamav/freshclam.conf
+fi
+
+if [[ ! -z "${CLAMD_CONF_FILE}" ]]; then
+    echo "[bootstrap] CLAMD_CONF_FILE set, copy to /etc/clamav/clam.conf"
+    mv /etc/clamav/clam.conf /etc/clamav/clam.conf.bak
+    cp -f ${FRESHCLAM_CONF_FILE} /etc/clamav/clam.conf
+fi
 
 MAIN_FILE="/var/lib/clamav/main.cvd"
 

--- a/alpine/edge/conf/freshclam.conf
+++ b/alpine/edge/conf/freshclam.conf
@@ -6,7 +6,6 @@ DatabaseDirectory /var/lib/clamav
 LogSyslog yes
 LogTime yes
 PidFile /run/clamav/freshclam.pid
-DatabaseOwner root
 
 ###############
 # Updates

--- a/alpine/main/bootstrap.sh
+++ b/alpine/main/bootstrap.sh
@@ -1,6 +1,17 @@
 #!/bin/bash
+set -e
 
-set -eu
+if [[ ! -z "${FRESHCLAM_CONF_FILE}" ]]; then
+    echo "[bootstrap] FRESHCLAM_CONF_FILE set, copy to /etc/clamav/freshclam.conf"
+    mv /etc/clamav/freshclam.conf /etc/clamav/freshclam.conf.bak
+    cp -f ${FRESHCLAM_CONF_FILE} /etc/clamav/freshclam.conf
+fi
+
+if [[ ! -z "${CLAMD_CONF_FILE}" ]]; then
+    echo "[bootstrap] CLAMD_CONF_FILE set, copy to /etc/clamav/clam.conf"
+    mv /etc/clamav/clam.conf /etc/clamav/clam.conf.bak
+    cp -f ${FRESHCLAM_CONF_FILE} /etc/clamav/clam.conf
+fi
 
 MAIN_FILE="/var/lib/clamav/main.cvd"
 

--- a/alpine/main/conf/freshclam.conf
+++ b/alpine/main/conf/freshclam.conf
@@ -6,7 +6,6 @@ DatabaseDirectory /var/lib/clamav
 LogSyslog yes
 LogTime yes
 PidFile /run/clamav/freshclam.pid
-DatabaseOwner root
 
 ###############
 # Updates

--- a/build-all.sh
+++ b/build-all.sh
@@ -1,10 +1,11 @@
 #!/bin/bash
-docker run --rm --privileged multiarch/qemu-user-static:register --reset
 
 if [ -z ${1} ] ; then
   echo "Repository not set. Provide a repository name in the format 'repo/'"
   exit 1
 fi
+
+docker run --rm --privileged multiarch/qemu-user-static:register --reset
 
 repo=${1}
 
@@ -12,63 +13,19 @@ docker build -t ${repo}docker-clamav:buster-slim-amd64 debian/buster/
 docker build -t ${repo}docker-clamav:buster-slim-armv7 -f debian/buster/Dockerfile.arm32v7 debian/buster/
 docker build -t ${repo}docker-clamav:buster-slim-arm64v8 -f debian/buster/Dockerfile.arm64v8 debian/buster/
 
-docker push ${repo}docker-clamav:buster-slim-amd64
-docker push ${repo}docker-clamav:buster-slim-armv7
-docker push ${repo}docker-clamav:buster-slim-arm64v8
-
 #armv7 cause problems in the moment
 docker build -t ${repo}docker-clamav:stretch-slim-amd64 debian/stretch/
 #docker build -t ${repo}docker-clamav:stretch-slim-armv7 -f debian/stretch/Dockerfile.arm32v7 debian/stretch/
 docker build -t ${repo}docker-clamav:stretch-slim-arm64v8 -f debian/stretch/Dockerfile.arm64v8 debian/stretch/
 
-docker push ${repo}docker-clamav:stretch-slim-amd64
-#docker push ${repo}docker-clamav:stretch-slim-armv7
-docker push ${repo}docker-clamav:stretch-slim-arm64v8
 
 docker build -t ${repo}docker-clamav:alpine-amd64 alpine/main/
 docker build -t ${repo}docker-clamav:alpine-armv7 -f alpine/main/Dockerfile.arm32v7 alpine/main/
 docker build -t ${repo}docker-clamav:alpine-arm64v8 -f alpine/main/Dockerfile.arm64v8 alpine/main/
 
-docker push ${repo}docker-clamav:alpine-amd64
-docker push ${repo}docker-clamav:alpine-armv7
-docker push ${repo}docker-clamav:alpine-arm64v8
 
 docker build -t ${repo}docker-clamav:alpine-edge-amd64 alpine/edge/
 docker build -t ${repo}docker-clamav:alpine-edge-armv7 -f alpine/edge/Dockerfile.arm32v7 alpine/edge/
 docker build -t ${repo}docker-clamav:alpine-edge-arm64v8 -f alpine/edge/Dockerfile.arm64v8 alpine/edge/
 
-docker push ${repo}docker-clamav:alpine-edge-amd64
-docker push ${repo}docker-clamav:alpine-edge-armv7
-docker push ${repo}docker-clamav:alpine-edge-arm64v8
 
-if ! test -f manifest-tool ; then
-  echo Ensure compatible version of manifest tool https://github.com/estesp/manifest-tool
-  curl -Lo manifest-tool https://github.com/estesp/manifest-tool/releases/download/v1.0.3/manifest-tool-linux-amd64
-  chmod +x manifest-tool
-fi
-
-./manifest-tool push from-args \
-    --platforms linux/amd64,linux/arm/v7,linux/arm64/v8 \
-    --template ${repo}docker-clamav:buster-slim-ARCHVARIANT \
-    --target ${repo}docker-clamav:buster-slim
-
-./manifest-tool push from-args \
-    --platforms linux/amd64,linux/arm/v7,linux/arm64/v8 \
-    --template ${repo}docker-clamav:buster-slim-ARCHVARIANT \
-    --target ${repo}docker-clamav:latest
-    
-./manifest-tool push from-args \
-    --platforms linux/amd64,linux/arm64/v8 \
-    --template ${repo}docker-clamav:stretch-slim-ARCHVARIANT \
-    --target ${repo}docker-clamav:stretch-slim
-
-./manifest-tool push from-args \
-    --platforms linux/amd64,linux/arm/v7,linux/arm64/v8 \
-    --template ${repo}docker-clamav:alpine-ARCHVARIANT \
-    --target ${repo}docker-clamav:alpine
-
-./manifest-tool push from-args \
-    --platforms linux/amd64,linux/arm/v7,linux/arm64/v8 \
-    --template ${repo}docker-clamav:alpine-edge-ARCHVARIANT \
-    --target ${repo}docker-clamav:alpine-edge
-    

--- a/debian/buster/Dockerfile
+++ b/debian/buster/Dockerfile
@@ -48,7 +48,7 @@ COPY bootstrap.sh /
 # port provision
 EXPOSE 3310
 
-RUN chown clamav:clamav bootstrap.sh check.sh envconfig.sh && \
+RUN chown clamav:clamav bootstrap.sh check.sh envconfig.sh /etc/clamav/clamd.conf /etc/clamav/freshclam.conf && \
     chmod u+x bootstrap.sh check.sh envconfig.sh    
 
 USER clamav

--- a/debian/buster/envconfig.sh
+++ b/debian/buster/envconfig.sh
@@ -1,5 +1,18 @@
 #!/bin/bash
 # update clamd.conf and freshclam.conf from env variables
+set -e
+
+if [[ ! -z "${FRESHCLAM_CONF_FILE}" ]]; then
+    echo "[bootstrap] FRESHCLAM_CONF_FILE set, copy to /etc/clamav/freshclam.conf"
+    mv /etc/clamav/freshclam.conf /etc/clamav/freshclam.conf.bak
+    cp -f ${FRESHCLAM_CONF_FILE} /etc/clamav/freshclam.conf
+fi
+
+if [[ ! -z "${CLAMD_CONF_FILE}" ]]; then
+    echo "[bootstrap] CLAMD_CONF_FILE set, copy to /etc/clamav/clam.conf"
+    mv /etc/clamav/clam.conf /etc/clamav/clam.conf.bak
+    cp -f ${FRESHCLAM_CONF_FILE} /etc/clamav/clam.conf
+fi
 
 for OUTPUT in $(env | awk -F "=" '{print $1}' | grep "^CLAMD_CONF_"); do
     TRIMMED="${OUTPUT/CLAMD_CONF_/}"

--- a/debian/stretch/Dockerfile
+++ b/debian/stretch/Dockerfile
@@ -40,7 +40,7 @@ EXPOSE 3310
 
 COPY bootstrap.sh /
 COPY check.sh /
-RUN chown clamav:clamav bootstrap.sh check.sh && \
+RUN chown clamav:clamav bootstrap.sh check.sh && /etc/clamav/clamd.conf /etc/clamav/freshclam.conf \
     chmod u+x bootstrap.sh check.sh
 
 USER clamav

--- a/debian/stretch/bootstrap.sh
+++ b/debian/stretch/bootstrap.sh
@@ -1,7 +1,19 @@
 #!/bin/bash
 # bootstrap clam av service and clam av database updater shell script
 # presented by mko (Markus Kosmal<dude@m-ko.de>)
-set -m
+set -e
+
+if [[ ! -z "${FRESHCLAM_CONF_FILE}" ]]; then
+    echo "[bootstrap] FRESHCLAM_CONF_FILE set, copy to /etc/clamav/freshclam.conf"
+    mv /etc/clamav/freshclam.conf /etc/clamav/freshclam.conf.bak
+    cp -f ${FRESHCLAM_CONF_FILE} /etc/clamav/freshclam.conf
+fi
+
+if [[ ! -z "${CLAMD_CONF_FILE}" ]]; then
+    echo "[bootstrap] CLAMD_CONF_FILE set, copy to /etc/clamav/clam.conf"
+    mv /etc/clamav/clam.conf /etc/clamav/clam.conf.bak
+    cp -f ${FRESHCLAM_CONF_FILE} /etc/clamav/clam.conf
+fi
 
 # start clam service itself and the updater in background as daemon
 freshclam -d &

--- a/push-all.sh
+++ b/push-all.sh
@@ -1,0 +1,55 @@
+#!/bin/bash
+if [ -z ${1} ] ; then
+  echo "Repository not set. Provide a repository name in the format 'repo/'"
+  exit 1
+fi
+
+repo=${1}
+
+docker push ${repo}docker-clamav:buster-slim-amd64
+docker push ${repo}docker-clamav:buster-slim-armv7
+docker push ${repo}docker-clamav:buster-slim-arm64v8
+
+docker push ${repo}docker-clamav:stretch-slim-amd64
+#docker push ${repo}docker-clamav:stretch-slim-armv7
+docker push ${repo}docker-clamav:stretch-slim-arm64v8
+
+docker push ${repo}docker-clamav:alpine-amd64
+docker push ${repo}docker-clamav:alpine-armv7
+docker push ${repo}docker-clamav:alpine-arm64v8
+
+docker push ${repo}docker-clamav:alpine-edge-amd64
+docker push ${repo}docker-clamav:alpine-edge-armv7
+docker push ${repo}docker-clamav:alpine-edge-arm64v8
+
+if ! test -f manifest-tool ; then
+  echo Ensure compatible version of manifest tool https://github.com/estesp/manifest-tool
+  curl -Lo manifest-tool https://github.com/estesp/manifest-tool/releases/download/v1.0.3/manifest-tool-linux-amd64
+  chmod +x manifest-tool
+fi
+
+./manifest-tool push from-args \
+    --platforms linux/amd64,linux/arm/v7,linux/arm64/v8 \
+    --template ${repo}docker-clamav:buster-slim-ARCHVARIANT \
+    --target ${repo}docker-clamav:buster-slim
+
+./manifest-tool push from-args \
+    --platforms linux/amd64,linux/arm/v7,linux/arm64/v8 \
+    --template ${repo}docker-clamav:buster-slim-ARCHVARIANT \
+    --target ${repo}docker-clamav:latest
+    
+./manifest-tool push from-args \
+    --platforms linux/amd64,linux/arm64/v8 \
+    --template ${repo}docker-clamav:stretch-slim-ARCHVARIANT \
+    --target ${repo}docker-clamav:stretch-slim
+
+./manifest-tool push from-args \
+    --platforms linux/amd64,linux/arm/v7,linux/arm64/v8 \
+    --template ${repo}docker-clamav:alpine-ARCHVARIANT \
+    --target ${repo}docker-clamav:alpine
+
+./manifest-tool push from-args \
+    --platforms linux/amd64,linux/arm/v7,linux/arm64/v8 \
+    --template ${repo}docker-clamav:alpine-edge-ARCHVARIANT \
+    --target ${repo}docker-clamav:alpine-edge
+    


### PR DESCRIPTION
Closes #81 

Adding env vars to set location to custom .conf files. The custom files will be copied to `/etc/clamav` and overwrite the corresponding files.