### PR TITLE
Fix environment-based config and permissions

### DIFF
--- a/alpine/edge/bootstrap.sh
+++ b/alpine/edge/bootstrap.sh
@@ -10,7 +10,7 @@ fi
 if [[ ! -z "${CLAMD_CONF_FILE}" ]]; then
     echo "[bootstrap] CLAMD_CONF_FILE set, copy to /etc/clamav/clam.conf"
     mv /etc/clamav/clamd.conf /etc/clamav/clamd.conf.bak
-    cp -f ${FRESHCLAM_CONF_FILE} /etc/clamav/clamd.conf
+    cp -f ${CLAMD_CONF_FILE} /etc/clamav/clamd.conf
 fi
 
 MAIN_FILE="/var/lib/clamav/main.cvd"

--- a/alpine/main/bootstrap.sh
+++ b/alpine/main/bootstrap.sh
@@ -10,7 +10,7 @@ fi
 if [[ ! -z "${CLAMD_CONF_FILE}" ]]; then
     echo "[bootstrap] CLAMD_CONF_FILE set, copy to /etc/clamav/clam.conf"
     mv /etc/clamav/clamd.conf /etc/clamav/clamd.conf.bak
-    cp -f ${FRESHCLAM_CONF_FILE} /etc/clamav/clamd.conf
+    cp -f ${CLAMD_CONF_FILE} /etc/clamav/clamd.conf
 fi
 
 MAIN_FILE="/var/lib/clamav/main.cvd"

--- a/debian/buster/Dockerfile
+++ b/debian/buster/Dockerfile
@@ -48,7 +48,7 @@ COPY bootstrap.sh /
 # port provision
 EXPOSE 3310
 
-RUN chown clamav:clamav bootstrap.sh check.sh envconfig.sh /etc/clamav/clamd.conf /etc/clamav/freshclam.conf && \
+RUN chown clamav:clamav bootstrap.sh check.sh envconfig.sh /etc/clamav /etc/clamav/clamd.conf /etc/clamav/freshclam.conf && \
     chmod u+x bootstrap.sh check.sh envconfig.sh    
 
 USER clamav

--- a/debian/buster/envconfig.sh
+++ b/debian/buster/envconfig.sh
@@ -11,7 +11,7 @@ fi
 if [[ ! -z "${CLAMD_CONF_FILE}" ]]; then
     echo "[bootstrap] CLAMD_CONF_FILE set, copy to /etc/clamav/clam.conf"
     mv /etc/clamav/clamd.conf /etc/clamav/clamd.conf.bak
-    cp -f ${FRESHCLAM_CONF_FILE} /etc/clamav/clamd.conf
+    cp -f ${CLAMD_CONF_FILE} /etc/clamav/clamd.conf
 fi
 
 for OUTPUT in $(env | awk -F "=" '{print $1}' | grep "^CLAMD_CONF_"); do

--- a/debian/stretch/Dockerfile
+++ b/debian/stretch/Dockerfile
@@ -40,7 +40,7 @@ EXPOSE 3310
 
 COPY bootstrap.sh /
 COPY check.sh /
-RUN chown clamav:clamav bootstrap.sh check.sh && /etc/clamav/clamd.conf /etc/clamav/freshclam.conf \
+RUN chown clamav:clamav bootstrap.sh check.sh && /etc/clamav /etc/clamav/clamd.conf /etc/clamav/freshclam.conf \
     chmod u+x bootstrap.sh check.sh
 
 USER clamav

--- a/debian/stretch/bootstrap.sh
+++ b/debian/stretch/bootstrap.sh
@@ -12,7 +12,7 @@ fi
 if [[ ! -z "${CLAMD_CONF_FILE}" ]]; then
     echo "[bootstrap] CLAMD_CONF_FILE set, copy to /etc/clamav/clam.conf"
     mv /etc/clamav/clamd.conf /etc/clamav/clamd.conf.bak
-    cp -f ${FRESHCLAM_CONF_FILE} /etc/clamav/clamd.conf
+    cp -f ${CLAMD_CONF_FILE} /etc/clamav/clamd.conf
 fi
 
 # start clam service itself and the updater in background as daemon


### PR DESCRIPTION
- Fix a bug where `FRESHCLAM_CONF_FILE` was used instead of `CLAMD_CONF_FILE`
- Change ownership of /etc/clamav to clamav so it doesn't fail to create tempfiles there when using config environment variables