### PR TITLE
Add proxy env parameter for alpine image

### DIFF
--- a/alpine/edge/bootstrap.sh
+++ b/alpine/edge/bootstrap.sh
@@ -13,6 +13,9 @@ if [[ ! -z "${CLAMD_CONF_FILE}" ]]; then
     cp -f ${CLAMD_CONF_FILE} /etc/clamav/clamd.conf
 fi
 
+if ! [ -z $HTTPProxyServer ]; then echo "HTTPProxyServer $HTTPProxyServer" >> /etc/clamav/freshclam.conf; fi && \
+if ! [ -z $HTTPProxyPort   ]; then echo "HTTPProxyPort $HTTPProxyPort" >> /etc/clamav/freshclam.conf; fi && \
+
 MAIN_FILE="/var/lib/clamav/main.cvd"
 
 if [ ! -f ${MAIN_FILE} ]; then

--- a/alpine/main/bootstrap.sh
+++ b/alpine/main/bootstrap.sh
@@ -13,6 +13,9 @@ if [[ ! -z "${CLAMD_CONF_FILE}" ]]; then
     cp -f ${CLAMD_CONF_FILE} /etc/clamav/clamd.conf
 fi
 
+if ! [ -z $HTTPProxyServer ]; then echo "HTTPProxyServer $HTTPProxyServer" >> /etc/clamav/freshclam.conf; fi && \
+if ! [ -z $HTTPProxyPort   ]; then echo "HTTPProxyPort $HTTPProxyPort" >> /etc/clamav/freshclam.conf; fi && \
+
 MAIN_FILE="/var/lib/clamav/main.cvd"
 
 if [ ! -f ${MAIN_FILE} ]; then


### PR DESCRIPTION
At the moment the proxy env parameter are ignored in the alpine images.

This pull request adds the same logic as it already exists in debian.