### PR TITLE
Fix missing freshclam logs in Alpine images

### DIFF
--- a/alpine/edge/Dockerfile
+++ b/alpine/edge/Dockerfile
@@ -1,7 +1,7 @@
 FROM alpine:edge
 LABEL maintainer="https://mko-x.github.io/docker-clamav/"
 
-RUN apk add --no-cache bash clamav rsyslog wget clamav-libunrar
+RUN apk add --no-cache bash clamav clamav-libunrar
 
 COPY conf /etc/clamav
 COPY bootstrap.sh /

--- a/alpine/edge/Dockerfile
+++ b/alpine/edge/Dockerfile
@@ -5,6 +5,7 @@ RUN apk add --no-cache bash clamav clamav-libunrar
 
 COPY conf /etc/clamav
 COPY bootstrap.sh /
+COPY envconfig.sh /
 COPY check.sh /
 
 RUN mkdir /var/run/clamav && \

--- a/alpine/edge/Dockerfile.arm32v7
+++ b/alpine/edge/Dockerfile.arm32v7
@@ -11,7 +11,7 @@ LABEL maintainer="Markus Kosmal <code@m-ko.de>"
 # copy qmeu
 COPY --from=qemu qemu-arm-static /usr/bin
 
-RUN apk add --no-cache bash clamav rsyslog wget clamav-libunrar
+RUN apk add --no-cache bash clamav clamav-libunrar
 
 COPY conf /etc/clamav
 COPY bootstrap.sh /

--- a/alpine/edge/Dockerfile.arm32v7
+++ b/alpine/edge/Dockerfile.arm32v7
@@ -15,6 +15,7 @@ RUN apk add --no-cache bash clamav clamav-libunrar
 
 COPY conf /etc/clamav
 COPY bootstrap.sh /
+COPY envconfig.sh /
 COPY check.sh /
 
 RUN mkdir /var/run/clamav && \

--- a/alpine/edge/Dockerfile.arm64v8
+++ b/alpine/edge/Dockerfile.arm64v8
@@ -11,7 +11,7 @@ LABEL maintainer="Markus Kosmal <code@m-ko.de>"
 # copy qmeu
 COPY --from=qemu qemu-aarch64-static /usr/bin
 
-RUN apk add --no-cache bash clamav rsyslog wget clamav-libunrar
+RUN apk add --no-cache bash clamav clamav-libunrar
 
 COPY conf /etc/clamav
 COPY bootstrap.sh /

--- a/alpine/edge/Dockerfile.arm64v8
+++ b/alpine/edge/Dockerfile.arm64v8
@@ -15,6 +15,7 @@ RUN apk add --no-cache bash clamav clamav-libunrar
 
 COPY conf /etc/clamav
 COPY bootstrap.sh /
+COPY envconfig.sh /
 COPY check.sh /
 
 RUN mkdir /var/run/clamav && \

--- a/alpine/edge/bootstrap.sh
+++ b/alpine/edge/bootstrap.sh
@@ -1,20 +1,17 @@
 #!/bin/bash
-set -e
+# bootstrap clam av service and clam av database updater shell script
+# presented by mko (Markus Kosmal<dude@m-ko.de>)
+set -m
 
-if [[ ! -z "${FRESHCLAM_CONF_FILE}" ]]; then
-    echo "[bootstrap] FRESHCLAM_CONF_FILE set, copy to /etc/clamav/freshclam.conf"
-    mv /etc/clamav/freshclam.conf /etc/clamav/freshclam.conf.bak
-    cp -f ${FRESHCLAM_CONF_FILE} /etc/clamav/freshclam.conf
-fi
-
-if [[ ! -z "${CLAMD_CONF_FILE}" ]]; then
-    echo "[bootstrap] CLAMD_CONF_FILE set, copy to /etc/clamav/clamd.conf"
-    mv /etc/clamav/clamd.conf /etc/clamav/clamd.conf.bak
-    cp -f ${CLAMD_CONF_FILE} /etc/clamav/clamd.conf
-fi
+# configure freshclam.conf and clamd.conf from env variables if present
+source /envconfig.sh
 
 if ! [ -z $HTTPProxyServer ]; then echo "HTTPProxyServer $HTTPProxyServer" >> /etc/clamav/freshclam.conf; fi && \
 if ! [ -z $HTTPProxyPort   ]; then echo "HTTPProxyPort $HTTPProxyPort" >> /etc/clamav/freshclam.conf; fi && \
+
+DB_DIR=$(sed -n 's/^DatabaseDirectory\s\(.*\)\s*$/\1/p' /etc/clamav/freshclam.conf )
+DB_DIR=${DB_DIR:-'/var/lib/clamav'}
+MAIN_FILE="$DB_DIR/main.cvd"
 
 DB_DIR=$(sed -n 's/^DatabaseDirectory\s\(.*\)\s*$/\1/p' /etc/clamav/freshclam.conf )
 DB_DIR=${DB_DIR:-'/var/lib/clamav'}
@@ -26,8 +23,33 @@ if [ ! -f ${MAIN_FILE} ]; then
     /usr/bin/freshclam
 fi
 
-echo "[bootstrap] Schedule freshclam DB updater."
-/usr/bin/freshclam -d
+# start clam service itself and the updater in background as daemon
+freshclam -d &
+clamd &
 
-echo "[bootstrap] Run clamav daemon..."
-exec /usr/sbin/clamd -c /etc/clamav/clamd.conf
+# recognize PIDs
+pidlist=$(jobs -p)
+
+# initialize latest result var
+latest_exit=0
+
+# define shutdown helper
+function shutdown() {
+    trap "" SIGINT
+
+    for single in $pidlist; do
+        if ! kill -0 "$single" 2> /dev/null; then
+            wait "$single"
+            latest_exit=$?
+        fi
+    done
+
+    kill "$pidlist" 2> /dev/null
+}
+
+# run shutdown
+trap shutdown SIGINT
+wait -n
+
+# return received result
+exit $latest_exit

--- a/alpine/edge/check.sh
+++ b/alpine/edge/check.sh
@@ -1,8 +1,8 @@
 #!/bin/sh
 
 if [ "$(echo PING | nc localhost 3310)" = "PONG" ]; then
-	echo "ping successful"
+    echo "ping successful"
 else
-	echo "ping failed"
-	exit 1
+    echo 1>&2 "ping failed"
+    exit 1
 fi

--- a/alpine/edge/conf/freshclam.conf
+++ b/alpine/edge/conf/freshclam.conf
@@ -3,16 +3,18 @@
 ###############
 
 DatabaseDirectory /var/lib/clamav
-LogSyslog yes
+LogSyslog false
 LogTime yes
 PidFile /run/clamav/freshclam.pid
+Foreground true
 
 ###############
 # Updates
 ###############
 
+DatabaseMirror db.local.clamav.net
 DatabaseMirror database.clamav.net
 ScriptedUpdates yes
 NotifyClamd /etc/clamav/clamd.conf
-SafeBrowsing no
+SafeBrowsing false
 Bytecode yes

--- a/alpine/edge/envconfig.sh
+++ b/alpine/edge/envconfig.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+# update clamd.conf and freshclam.conf from env variables
+set -e
+
+if [[ ! -z "${FRESHCLAM_CONF_FILE}" ]]; then
+    echo "[bootstrap] FRESHCLAM_CONF_FILE set, copy to /etc/clamav/freshclam.conf"
+    mv /etc/clamav/freshclam.conf /etc/clamav/freshclam.conf.bak
+    cp -f ${FRESHCLAM_CONF_FILE} /etc/clamav/freshclam.conf
+fi
+
+if [[ ! -z "${CLAMD_CONF_FILE}" ]]; then
+    echo "[bootstrap] CLAMD_CONF_FILE set, copy to /etc/clamav/clamd.conf"
+    mv /etc/clamav/clamd.conf /etc/clamav/clamd.conf.bak
+    cp -f ${CLAMD_CONF_FILE} /etc/clamav/clamd.conf
+fi
+
+for OUTPUT in $(env | awk -F "=" '{print $1}' | grep "^CLAMD_CONF_"); do
+    TRIMMED="${OUTPUT/CLAMD_CONF_/}"
+    grep -q "^$TRIMMED " /etc/clamav/clamd.conf && sed "s/^$TRIMMED .*/$TRIMMED ${!OUTPUT}/" -i /etc/clamav/clamd.conf ||
+        sed "$ a\\$TRIMMED ${!OUTPUT}" -i /etc/clamav/clamd.conf
+done
+
+for OUTPUT in $(env | awk -F "=" '{print $1}' | grep "^FRESHCLAM_CONF_"); do
+    TRIMMED="${OUTPUT/FRESHCLAM_CONF_/}"
+    grep -q "^$TRIMMED " /etc/clamav/freshclam.conf && sed "s/^$TRIMMED .*/$TRIMMED ${!OUTPUT}/" -i /etc/clamav/freshclam.conf ||
+        sed "$ a\\$TRIMMED ${!OUTPUT}" -i /etc/clamav/freshclam.conf
+done

--- a/alpine/main/Dockerfile
+++ b/alpine/main/Dockerfile
@@ -1,7 +1,7 @@
 FROM alpine:3.12
 LABEL maintainer="Markus Kosmal <code@m-ko.de>"
 
-RUN apk add --no-cache bash clamav clamav-daemon rsyslog wget clamav-libunrar
+RUN apk add --no-cache bash clamav clamav-daemon clamav-libunrar
 
 COPY conf /etc/clamav
 COPY bootstrap.sh /

--- a/alpine/main/Dockerfile
+++ b/alpine/main/Dockerfile
@@ -5,6 +5,7 @@ RUN apk add --no-cache bash clamav clamav-daemon clamav-libunrar
 
 COPY conf /etc/clamav
 COPY bootstrap.sh /
+COPY envconfig.sh /
 COPY check.sh /
 
 RUN mkdir /var/run/clamav && \

--- a/alpine/main/Dockerfile.arm32v7
+++ b/alpine/main/Dockerfile.arm32v7
@@ -10,7 +10,7 @@ LABEL maintainer="Markus Kosmal <code@m-ko.de>"
 # copy qmeu
 COPY --from=qemu qemu-arm-static /usr/bin
 
-RUN apk add --no-cache bash clamav rsyslog wget clamav-libunrar
+RUN apk add --no-cache bash clamav clamav-libunrar
 
 COPY conf /etc/clamav
 COPY bootstrap.sh /

--- a/alpine/main/Dockerfile.arm32v7
+++ b/alpine/main/Dockerfile.arm32v7
@@ -14,6 +14,7 @@ RUN apk add --no-cache bash clamav clamav-libunrar
 
 COPY conf /etc/clamav
 COPY bootstrap.sh /
+COPY envconfig.sh /
 COPY check.sh /
 
 RUN mkdir /var/run/clamav && \

--- a/alpine/main/Dockerfile.arm64v8
+++ b/alpine/main/Dockerfile.arm64v8
@@ -10,7 +10,7 @@ LABEL maintainer="Markus Kosmal <code@m-ko.de>"
 # copy qmeu
 COPY --from=qemu qemu-aarch64-static /usr/bin
 
-RUN apk add --no-cache bash clamav rsyslog wget clamav-libunrar
+RUN apk add --no-cache bash clamav clamav-libunrar
 
 COPY conf /etc/clamav
 COPY bootstrap.sh /

--- a/alpine/main/Dockerfile.arm64v8
+++ b/alpine/main/Dockerfile.arm64v8
@@ -14,6 +14,7 @@ RUN apk add --no-cache bash clamav clamav-libunrar
 
 COPY conf /etc/clamav
 COPY bootstrap.sh /
+COPY envconfig.sh /
 COPY check.sh /
 
 RUN mkdir /var/run/clamav && \

--- a/alpine/main/bootstrap.sh
+++ b/alpine/main/bootstrap.sh
@@ -1,20 +1,17 @@
 #!/bin/bash
-set -e
+# bootstrap clam av service and clam av database updater shell script
+# presented by mko (Markus Kosmal<dude@m-ko.de>)
+set -m
 
-if [[ ! -z "${FRESHCLAM_CONF_FILE}" ]]; then
-    echo "[bootstrap] FRESHCLAM_CONF_FILE set, copy to /etc/clamav/freshclam.conf"
-    mv /etc/clamav/freshclam.conf /etc/clamav/freshclam.conf.bak
-    cp -f ${FRESHCLAM_CONF_FILE} /etc/clamav/freshclam.conf
-fi
-
-if [[ ! -z "${CLAMD_CONF_FILE}" ]]; then
-    echo "[bootstrap] CLAMD_CONF_FILE set, copy to /etc/clamav/clamd.conf"
-    mv /etc/clamav/clamd.conf /etc/clamav/clamd.conf.bak
-    cp -f ${CLAMD_CONF_FILE} /etc/clamav/clamd.conf
-fi
+# configure freshclam.conf and clamd.conf from env variables if present
+source /envconfig.sh
 
 if ! [ -z $HTTPProxyServer ]; then echo "HTTPProxyServer $HTTPProxyServer" >> /etc/clamav/freshclam.conf; fi && \
 if ! [ -z $HTTPProxyPort   ]; then echo "HTTPProxyPort $HTTPProxyPort" >> /etc/clamav/freshclam.conf; fi && \
+
+DB_DIR=$(sed -n 's/^DatabaseDirectory\s\(.*\)\s*$/\1/p' /etc/clamav/freshclam.conf )
+DB_DIR=${DB_DIR:-'/var/lib/clamav'}
+MAIN_FILE="$DB_DIR/main.cvd"
 
 DB_DIR=$(sed -n 's/^DatabaseDirectory\s\(.*\)\s*$/\1/p' /etc/clamav/freshclam.conf )
 DB_DIR=${DB_DIR:-'/var/lib/clamav'}
@@ -26,8 +23,33 @@ if [ ! -f ${MAIN_FILE} ]; then
     /usr/bin/freshclam
 fi
 
-echo "[bootstrap] Schedule freshclam DB updater."
-/usr/bin/freshclam -d
+# start clam service itself and the updater in background as daemon
+freshclam -d &
+clamd &
 
-echo "[bootstrap] Run clamav daemon..."
-exec /usr/sbin/clamd -c /etc/clamav/clamd.conf
+# recognize PIDs
+pidlist=$(jobs -p)
+
+# initialize latest result var
+latest_exit=0
+
+# define shutdown helper
+function shutdown() {
+    trap "" SIGINT
+
+    for single in $pidlist; do
+        if ! kill -0 "$single" 2> /dev/null; then
+            wait "$single"
+            latest_exit=$?
+        fi
+    done
+
+    kill "$pidlist" 2> /dev/null
+}
+
+# run shutdown
+trap shutdown SIGINT
+wait -n
+
+# return received result
+exit $latest_exit

--- a/alpine/main/check.sh
+++ b/alpine/main/check.sh
@@ -1,8 +1,8 @@
 #!/bin/sh
 
 if [ "$(echo PING | nc localhost 3310)" = "PONG" ]; then
-	echo "ping successful"
+    echo "ping successful"
 else
-	echo "ping failed"
-	exit 1
+    echo 1>&2 "ping failed"
+    exit 1
 fi

--- a/alpine/main/conf/freshclam.conf
+++ b/alpine/main/conf/freshclam.conf
@@ -3,16 +3,18 @@
 ###############
 
 DatabaseDirectory /var/lib/clamav
-LogSyslog yes
+LogSyslog false
 LogTime yes
 PidFile /run/clamav/freshclam.pid
+Foreground true
 
 ###############
 # Updates
 ###############
 
+DatabaseMirror db.local.clamav.net
 DatabaseMirror database.clamav.net
 ScriptedUpdates yes
 NotifyClamd /etc/clamav/clamd.conf
-SafeBrowsing no
+SafeBrowsing false
 Bytecode yes

--- a/alpine/main/envconfig.sh
+++ b/alpine/main/envconfig.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+# update clamd.conf and freshclam.conf from env variables
+set -e
+
+if [[ ! -z "${FRESHCLAM_CONF_FILE}" ]]; then
+    echo "[bootstrap] FRESHCLAM_CONF_FILE set, copy to /etc/clamav/freshclam.conf"
+    mv /etc/clamav/freshclam.conf /etc/clamav/freshclam.conf.bak
+    cp -f ${FRESHCLAM_CONF_FILE} /etc/clamav/freshclam.conf
+fi
+
+if [[ ! -z "${CLAMD_CONF_FILE}" ]]; then
+    echo "[bootstrap] CLAMD_CONF_FILE set, copy to /etc/clamav/clamd.conf"
+    mv /etc/clamav/clamd.conf /etc/clamav/clamd.conf.bak
+    cp -f ${CLAMD_CONF_FILE} /etc/clamav/clamd.conf
+fi
+
+for OUTPUT in $(env | awk -F "=" '{print $1}' | grep "^CLAMD_CONF_"); do
+    TRIMMED="${OUTPUT/CLAMD_CONF_/}"
+    grep -q "^$TRIMMED " /etc/clamav/clamd.conf && sed "s/^$TRIMMED .*/$TRIMMED ${!OUTPUT}/" -i /etc/clamav/clamd.conf ||
+        sed "$ a\\$TRIMMED ${!OUTPUT}" -i /etc/clamav/clamd.conf
+done
+
+for OUTPUT in $(env | awk -F "=" '{print $1}' | grep "^FRESHCLAM_CONF_"); do
+    TRIMMED="${OUTPUT/FRESHCLAM_CONF_/}"
+    grep -q "^$TRIMMED " /etc/clamav/freshclam.conf && sed "s/^$TRIMMED .*/$TRIMMED ${!OUTPUT}/" -i /etc/clamav/freshclam.conf ||
+        sed "$ a\\$TRIMMED ${!OUTPUT}" -i /etc/clamav/freshclam.conf
+done


### PR DESCRIPTION
I noticed the `freshclam` process output is no visible once the daemon is running in the Alpine based images.
Only the output of the initial `freshclam` run is shown but not of the daemon process running afterwards.

While this is not super critical, the output is useful for debugging and also for verifying correctness of updating the databases in long running containers.

While attempting to fix this, I took the opportunity to refactor the code a bit and especially tried to unify `check.sh` and `bootstrap.sh` with the Debian based flavors.