### PR TITLE
Add build with versioning

### DIFF
--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -1,0 +1,61 @@
+name: build-and-push
+
+# Controls when the action will run. Triggers the workflow on push or pull request
+# events but only for the master branch
+on:
+  push:
+    branches: [ master ]
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        tag: ["alpine", "alpine-edge", "buster", "strech"]
+        include:
+          - tag: "alpine"
+            path: "./alpine/main"
+          - tag:  "alpine-edge"
+            path: "./alpine/edge"
+          - tag: "buster"
+            path: "./debian/buster"
+          - tag: "stretch"
+            path: "./debian/stretch"
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      
+      - name: Install GitVersion
+        uses: gittools/actions/gitversion/setup@v0.9.4
+        with:
+          versionSpec: '5.x'
+        
+      - name: Use GitVersion
+        id: gitversion
+        uses: gittools/actions/gitversion/execute@v0.9.4
+        
+      - name: Docker Setup QEMU
+        uses: docker/setup-qemu-action@v1.0.1
+        
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+
+      - name: Login to DockerHub
+        uses: docker/login-action@v1 
+        with:
+          username: ${{ secrets.DOCKERHUBUSERNAME }}
+          password: ${{ secrets.DOCKERHUBTOKEN }}
+        
+      - name: Build and Push with version
+        uses: docker/build-push-action@v2.0.1
+        with:
+          tags: |
+            mkodockx/docker-clamav:${{ steps.gitversion.outputs.semVer }}-${{ matrix.tag }}         
+            mkodockx/docker-clamav:${{ matrix.tag }} 
+          file: ${{ matrix.path }}/Dockerfile
+          context: ${{ matrix.path }}
+          platforms: linux/amd64,linux/arm/v7,linux/arm64/v8
+          push: true

--- a/GitVersion.yml
+++ b/GitVersion.yml
@@ -1,0 +1,3 @@
+#see https://gitversion.net/ for docs
+mode: ContinuousDeployment
+next-version: 1.0.0


### PR DESCRIPTION
Close #80 

**The matrix part is untested!**

- Adding action to build and version images
- Pushing images to github with version and set `latest` tag to the latest pushed version
- using mainline gitversion mode, starting with 1.0.0

I suggest @mko-x is testing the action. Again, little to no time to really support more (sorry)