### PR TITLE
Do not add/replace configuration file environment variable names

### DIFF
--- a/debian/buster/envconfig.sh
+++ b/debian/buster/envconfig.sh
@@ -15,12 +15,16 @@ if [[ ! -z "${CLAMD_CONF_FILE}" ]]; then
 fi
 
 for OUTPUT in $(env | awk -F "=" '{print $1}' | grep "^CLAMD_CONF_"); do
+    test "$OUTPUT" = "CLAMD_CONF_FILE" && continue  # skip configuration file variable
+
     TRIMMED="${OUTPUT/CLAMD_CONF_/}"
     grep -q "^$TRIMMED " /etc/clamav/clamd.conf && sed "s/^$TRIMMED .*/$TRIMMED ${!OUTPUT}/" -i /etc/clamav/clamd.conf ||
         sed "$ a\\$TRIMMED ${!OUTPUT}" -i /etc/clamav/clamd.conf
 done
 
 for OUTPUT in $(env | awk -F "=" '{print $1}' | grep "^FRESHCLAM_CONF_"); do
+    test "$OUTPUT" = "FRESHCLAM_CONF_FILE" && continue  # skip configuration file variable
+
     TRIMMED="${OUTPUT/FRESHCLAM_CONF_/}"
     grep -q "^$TRIMMED " /etc/clamav/freshclam.conf && sed "s/^$TRIMMED .*/$TRIMMED ${!OUTPUT}/" -i /etc/clamav/freshclam.conf ||
         sed "$ a\\$TRIMMED ${!OUTPUT}" -i /etc/clamav/freshclam.conf


### PR DESCRIPTION
This should fix the too eager replacement of `CLAMD_CONF_FILE` and `FRESHCLAM_CONF_FILE` environment variables in the resulting configuration files.
This was introduced in #31 but leads to `FILE /...` configuration items which are invalid.
When replacing matching environment variables, skip just the two for the configuration files.