### PR TITLE
Alpine: Use bootstrap script from Debian flavor to unify daemon behavior

### DIFF
--- a/alpine/edge/Dockerfile
+++ b/alpine/edge/Dockerfile
@@ -5,6 +5,7 @@ RUN apk add --no-cache bash clamav clamav-libunrar
 
 COPY conf /etc/clamav
 COPY bootstrap.sh /
+COPY envconfig.sh /
 COPY check.sh /
 
 RUN mkdir /var/run/clamav && \

--- a/alpine/edge/Dockerfile.arm32v7
+++ b/alpine/edge/Dockerfile.arm32v7
@@ -15,6 +15,7 @@ RUN apk add --no-cache bash clamav clamav-libunrar
 
 COPY conf /etc/clamav
 COPY bootstrap.sh /
+COPY envconfig.sh /
 COPY check.sh /
 
 RUN mkdir /var/run/clamav && \

--- a/alpine/edge/Dockerfile.arm64v8
+++ b/alpine/edge/Dockerfile.arm64v8
@@ -15,6 +15,7 @@ RUN apk add --no-cache bash clamav clamav-libunrar
 
 COPY conf /etc/clamav
 COPY bootstrap.sh /
+COPY envconfig.sh /
 COPY check.sh /
 
 RUN mkdir /var/run/clamav && \

--- a/alpine/edge/bootstrap.sh
+++ b/alpine/edge/bootstrap.sh
@@ -1,17 +1,10 @@
 #!/bin/bash
-set -e
+# bootstrap clam av service and clam av database updater shell script
+# presented by mko (Markus Kosmal<dude@m-ko.de>)
+set -m
 
-if [[ ! -z "${FRESHCLAM_CONF_FILE}" ]]; then
-    echo "[bootstrap] FRESHCLAM_CONF_FILE set, copy to /etc/clamav/freshclam.conf"
-    mv /etc/clamav/freshclam.conf /etc/clamav/freshclam.conf.bak
-    cp -f ${FRESHCLAM_CONF_FILE} /etc/clamav/freshclam.conf
-fi
-
-if [[ ! -z "${CLAMD_CONF_FILE}" ]]; then
-    echo "[bootstrap] CLAMD_CONF_FILE set, copy to /etc/clamav/clamd.conf"
-    mv /etc/clamav/clamd.conf /etc/clamav/clamd.conf.bak
-    cp -f ${CLAMD_CONF_FILE} /etc/clamav/clamd.conf
-fi
+# configure freshclam.conf and clamd.conf from env variables if present
+source /envconfig.sh
 
 if ! [ -z $HTTPProxyServer ]; then echo "HTTPProxyServer $HTTPProxyServer" >> /etc/clamav/freshclam.conf; fi && \
 if ! [ -z $HTTPProxyPort   ]; then echo "HTTPProxyPort $HTTPProxyPort" >> /etc/clamav/freshclam.conf; fi && \
@@ -26,8 +19,33 @@ if [ ! -f ${MAIN_FILE} ]; then
     /usr/bin/freshclam
 fi
 
-echo "[bootstrap] Schedule freshclam DB updater."
-/usr/bin/freshclam -d
+# start clam service itself and the updater in background as daemon
+freshclam -d &
+clamd &
 
-echo "[bootstrap] Run clamav daemon..."
-exec /usr/sbin/clamd -c /etc/clamav/clamd.conf
+# recognize PIDs
+pidlist=$(jobs -p)
+
+# initialize latest result var
+latest_exit=0
+
+# define shutdown helper
+function shutdown() {
+    trap "" SIGINT
+
+    for single in $pidlist; do
+        if ! kill -0 "$single" 2> /dev/null; then
+            wait "$single"
+            latest_exit=$?
+        fi
+    done
+
+    kill "$pidlist" 2> /dev/null
+}
+
+# run shutdown
+trap shutdown SIGINT
+wait -n
+
+# return received result
+exit $latest_exit

--- a/alpine/edge/conf/freshclam.conf
+++ b/alpine/edge/conf/freshclam.conf
@@ -3,16 +3,18 @@
 ###############
 
 DatabaseDirectory /var/lib/clamav
-LogSyslog yes
+LogSyslog false
 LogTime yes
 PidFile /run/clamav/freshclam.pid
+Foreground true
 
 ###############
 # Updates
 ###############
 
+DatabaseMirror db.local.clamav.net
 DatabaseMirror database.clamav.net
 ScriptedUpdates yes
 NotifyClamd /etc/clamav/clamd.conf
-SafeBrowsing no
+SafeBrowsing false
 Bytecode yes

--- a/alpine/edge/envconfig.sh
+++ b/alpine/edge/envconfig.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+# update clamd.conf and freshclam.conf from env variables
+set -e
+
+if [[ ! -z "${FRESHCLAM_CONF_FILE}" ]]; then
+    echo "[bootstrap] FRESHCLAM_CONF_FILE set, copy to /etc/clamav/freshclam.conf"
+    mv /etc/clamav/freshclam.conf /etc/clamav/freshclam.conf.bak
+    cp -f ${FRESHCLAM_CONF_FILE} /etc/clamav/freshclam.conf
+fi
+
+if [[ ! -z "${CLAMD_CONF_FILE}" ]]; then
+    echo "[bootstrap] CLAMD_CONF_FILE set, copy to /etc/clamav/clamd.conf"
+    mv /etc/clamav/clamd.conf /etc/clamav/clamd.conf.bak
+    cp -f ${CLAMD_CONF_FILE} /etc/clamav/clamd.conf
+fi
+
+for OUTPUT in $(env | awk -F "=" '{print $1}' | grep "^CLAMD_CONF_"); do
+    test "$OUTPUT" = "CLAMD_CONF_FILE" && continue  # skip configuration file variable
+
+    TRIMMED="${OUTPUT/CLAMD_CONF_/}"
+    grep -q "^$TRIMMED " /etc/clamav/clamd.conf && sed "s/^$TRIMMED .*/$TRIMMED ${!OUTPUT}/" -i /etc/clamav/clamd.conf ||
+        sed "$ a\\$TRIMMED ${!OUTPUT}" -i /etc/clamav/clamd.conf
+done
+
+for OUTPUT in $(env | awk -F "=" '{print $1}' | grep "^FRESHCLAM_CONF_"); do
+    test "$OUTPUT" = "FRESHCLAM_CONF_FILE" && continue  # skip configuration file variable
+
+    TRIMMED="${OUTPUT/FRESHCLAM_CONF_/}"
+    grep -q "^$TRIMMED " /etc/clamav/freshclam.conf && sed "s/^$TRIMMED .*/$TRIMMED ${!OUTPUT}/" -i /etc/clamav/freshclam.conf ||
+        sed "$ a\\$TRIMMED ${!OUTPUT}" -i /etc/clamav/freshclam.conf
+done

--- a/alpine/main/Dockerfile
+++ b/alpine/main/Dockerfile
@@ -5,6 +5,7 @@ RUN apk add --no-cache bash clamav clamav-daemon clamav-libunrar
 
 COPY conf /etc/clamav
 COPY bootstrap.sh /
+COPY envconfig.sh /
 COPY check.sh /
 
 RUN mkdir /var/run/clamav && \

--- a/alpine/main/Dockerfile.arm32v7
+++ b/alpine/main/Dockerfile.arm32v7
@@ -14,6 +14,7 @@ RUN apk add --no-cache bash clamav clamav-libunrar
 
 COPY conf /etc/clamav
 COPY bootstrap.sh /
+COPY envconfig.sh /
 COPY check.sh /
 
 RUN mkdir /var/run/clamav && \

--- a/alpine/main/Dockerfile.arm64v8
+++ b/alpine/main/Dockerfile.arm64v8
@@ -14,6 +14,7 @@ RUN apk add --no-cache bash clamav clamav-libunrar
 
 COPY conf /etc/clamav
 COPY bootstrap.sh /
+COPY envconfig.sh /
 COPY check.sh /
 
 RUN mkdir /var/run/clamav && \

--- a/alpine/main/bootstrap.sh
+++ b/alpine/main/bootstrap.sh
@@ -1,17 +1,10 @@
 #!/bin/bash
-set -e
+# bootstrap clam av service and clam av database updater shell script
+# presented by mko (Markus Kosmal<dude@m-ko.de>)
+set -m
 
-if [[ ! -z "${FRESHCLAM_CONF_FILE}" ]]; then
-    echo "[bootstrap] FRESHCLAM_CONF_FILE set, copy to /etc/clamav/freshclam.conf"
-    mv /etc/clamav/freshclam.conf /etc/clamav/freshclam.conf.bak
-    cp -f ${FRESHCLAM_CONF_FILE} /etc/clamav/freshclam.conf
-fi
-
-if [[ ! -z "${CLAMD_CONF_FILE}" ]]; then
-    echo "[bootstrap] CLAMD_CONF_FILE set, copy to /etc/clamav/clamd.conf"
-    mv /etc/clamav/clamd.conf /etc/clamav/clamd.conf.bak
-    cp -f ${CLAMD_CONF_FILE} /etc/clamav/clamd.conf
-fi
+# configure freshclam.conf and clamd.conf from env variables if present
+source /envconfig.sh
 
 if ! [ -z $HTTPProxyServer ]; then echo "HTTPProxyServer $HTTPProxyServer" >> /etc/clamav/freshclam.conf; fi && \
 if ! [ -z $HTTPProxyPort   ]; then echo "HTTPProxyPort $HTTPProxyPort" >> /etc/clamav/freshclam.conf; fi && \
@@ -26,8 +19,33 @@ if [ ! -f ${MAIN_FILE} ]; then
     /usr/bin/freshclam
 fi
 
-echo "[bootstrap] Schedule freshclam DB updater."
-/usr/bin/freshclam -d
+# start clam service itself and the updater in background as daemon
+freshclam -d &
+clamd &
 
-echo "[bootstrap] Run clamav daemon..."
-exec /usr/sbin/clamd -c /etc/clamav/clamd.conf
+# recognize PIDs
+pidlist=$(jobs -p)
+
+# initialize latest result var
+latest_exit=0
+
+# define shutdown helper
+function shutdown() {
+    trap "" SIGINT
+
+    for single in $pidlist; do
+        if ! kill -0 "$single" 2> /dev/null; then
+            wait "$single"
+            latest_exit=$?
+        fi
+    done
+
+    kill "$pidlist" 2> /dev/null
+}
+
+# run shutdown
+trap shutdown SIGINT
+wait -n
+
+# return received result
+exit $latest_exit

--- a/alpine/main/conf/freshclam.conf
+++ b/alpine/main/conf/freshclam.conf
@@ -3,16 +3,18 @@
 ###############
 
 DatabaseDirectory /var/lib/clamav
-LogSyslog yes
+LogSyslog false
 LogTime yes
 PidFile /run/clamav/freshclam.pid
+Foreground true
 
 ###############
 # Updates
 ###############
 
+DatabaseMirror db.local.clamav.net
 DatabaseMirror database.clamav.net
 ScriptedUpdates yes
 NotifyClamd /etc/clamav/clamd.conf
-SafeBrowsing no
+SafeBrowsing false
 Bytecode yes

--- a/alpine/main/envconfig.sh
+++ b/alpine/main/envconfig.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+# update clamd.conf and freshclam.conf from env variables
+set -e
+
+if [[ ! -z "${FRESHCLAM_CONF_FILE}" ]]; then
+    echo "[bootstrap] FRESHCLAM_CONF_FILE set, copy to /etc/clamav/freshclam.conf"
+    mv /etc/clamav/freshclam.conf /etc/clamav/freshclam.conf.bak
+    cp -f ${FRESHCLAM_CONF_FILE} /etc/clamav/freshclam.conf
+fi
+
+if [[ ! -z "${CLAMD_CONF_FILE}" ]]; then
+    echo "[bootstrap] CLAMD_CONF_FILE set, copy to /etc/clamav/clamd.conf"
+    mv /etc/clamav/clamd.conf /etc/clamav/clamd.conf.bak
+    cp -f ${CLAMD_CONF_FILE} /etc/clamav/clamd.conf
+fi
+
+for OUTPUT in $(env | awk -F "=" '{print $1}' | grep "^CLAMD_CONF_"); do
+    test "$OUTPUT" = "CLAMD_CONF_FILE" && continue  # skip configuration file variable
+
+    TRIMMED="${OUTPUT/CLAMD_CONF_/}"
+    grep -q "^$TRIMMED " /etc/clamav/clamd.conf && sed "s/^$TRIMMED .*/$TRIMMED ${!OUTPUT}/" -i /etc/clamav/clamd.conf ||
+        sed "$ a\\$TRIMMED ${!OUTPUT}" -i /etc/clamav/clamd.conf
+done
+
+for OUTPUT in $(env | awk -F "=" '{print $1}' | grep "^FRESHCLAM_CONF_"); do
+    test "$OUTPUT" = "FRESHCLAM_CONF_FILE" && continue  # skip configuration file variable
+
+    TRIMMED="${OUTPUT/FRESHCLAM_CONF_/}"
+    grep -q "^$TRIMMED " /etc/clamav/freshclam.conf && sed "s/^$TRIMMED .*/$TRIMMED ${!OUTPUT}/" -i /etc/clamav/freshclam.conf ||
+        sed "$ a\\$TRIMMED ${!OUTPUT}" -i /etc/clamav/freshclam.conf
+done


### PR DESCRIPTION
This makes the Debian and Alpine image flavors more similar especially
regarding daemon startup and control.
A side effect is that the output of the "freshclam" process is logged
to stdout as well (it was directed to /dev/null before).