### PR TITLE
Bootstrap an empty volume using the embedded virus database

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ Mount custom configuration files into the container.
 - CLAMD_CONF_FILE: Set the path to a custom `clamd.conf` file, e.g. `/mnt/clamd.conf`.
 
 ## Persistency
-Virus update definitions are stored in `/var/lib/clamav`. To store the defintion just mount the directory as a volume, `docker run -d -p 3310:3310 -v ./clamav:/var/lib/clamav mkodockx/docker-clamav:latest`
+Virus update definitions are stored in `/var/lib/clamav`. To store the defintion just mount the directory as a volume, `docker run -d -p 3310:3310 -v $(pwd)/clamav:/var/lib/clamav mkodockx/docker-clamav:latest`
 
 ## docker-compose
 See example with Nextcloud at [docker-compose.yml](https://github.com/mko-x/docker-clamav/blob/master/docker-compose.yml). You still need to configure the *AntiVirus files* app in Nextcloud.

--- a/alpine/main-idb/Dockerfile
+++ b/alpine/main-idb/Dockerfile
@@ -10,8 +10,11 @@ COPY ./daily.cvd  /var/lib/clamav/daily.cvd
 COPY ./bytecode.cvd  /var/lib/clamav/bytecode.cvd
 COPY ./safebrowsing.cvd  /var/lib/clamav/safebrowsing.cvd
 
+# setup alternative versions in case someone setups an empty mount over /var/lib/clamav
+RUN mkdir -p /var/lib/clamav.source && ln /var/lib/clamav/* /var/lib/clamav.source
+
 # permission juggling
-RUN chown clamav:clamav /var/lib/clamav/*.cvd
+RUN chown clamav:clamav /var/lib/clamav/*.cvd /var/lib/clamav.source
 
 EXPOSE 3310/tcp
 

--- a/alpine/main-idb/Dockerfile.arm32v7
+++ b/alpine/main-idb/Dockerfile.arm32v7
@@ -18,8 +18,11 @@ COPY ./daily.cvd  /var/lib/clamav/daily.cvd
 COPY ./bytecode.cvd  /var/lib/clamav/bytecode.cvd
 COPY ./safebrowsing.cvd  /var/lib/clamav/safebrowsing.cvd
 
+# setup alternative versions in case someone setups an empty mount over /var/lib/clamav
+RUN mkdir -p /var/lib/clamav.source && ln /var/lib/clamav/* /var/lib/clamav.source
+
 # permission juggling
-RUN chown clamav:clamav /var/lib/clamav/*.cvd
+RUN chown clamav:clamav /var/lib/clamav/*.cvd /var/lib/clamav.source
 
 EXPOSE 3310/tcp
 

--- a/alpine/main-idb/Dockerfile.arm64v8
+++ b/alpine/main-idb/Dockerfile.arm64v8
@@ -18,8 +18,11 @@ COPY ./daily.cvd  /var/lib/clamav/daily.cvd
 COPY ./bytecode.cvd  /var/lib/clamav/bytecode.cvd
 COPY ./safebrowsing.cvd  /var/lib/clamav/safebrowsing.cvd
 
+# setup alternative versions in case someone setups an empty mount over /var/lib/clamav
+RUN mkdir -p /var/lib/clamav.source && ln /var/lib/clamav/* /var/lib/clamav.source
+
 # permission juggling
-RUN chown clamav:clamav /var/lib/clamav/*.cvd
+RUN chown clamav:clamav /var/lib/clamav/*.cvd /var/lib/clamav.source
 
 EXPOSE 3310/tcp
 

--- a/alpine/main/bootstrap.sh
+++ b/alpine/main/bootstrap.sh
@@ -13,6 +13,12 @@ DB_DIR=$(sed -n 's/^DatabaseDirectory\s\(.*\)\s*$/\1/p' /etc/clamav/freshclam.co
 DB_DIR=${DB_DIR:-'/var/lib/clamav'}
 MAIN_FILE="$DB_DIR/main.cvd"
 
+# if /var/lib/clamav/ doesn't have the virus database..
+if [ ! -f "$MAIN_FILE" ] && [ -f /var/lib/clamav.source/main.cvd ]; then
+  # ..initialize it using the database we shipped in the docker image
+  cp /var/lib/clamav.source/*.cvd "$DB_DIR"
+fi
+
 function clam_start () {
     if [[ ! -e /var/run/clamav/created ]]
     then


### PR DESCRIPTION
Starting docker-clamav with an empty volume causes the virus database to be re-downloaded which apparently is to be avoided

This PR stores hardlinks to the embedded .cvd databases so that they can be copied to an empty volume if needed to bootstrap the container. This PR also fixes the example in README.md (but doesn't update it to explain the required permissions though)

Tested with (after building)
```
mkdir /tmp/clamav
chown -R 100:101 /tmp/clamav
docker run --rm -ti -v /tmp/clamav:/var/lib/clamav docker.io/mkodockx/docker-clamav:alpine-idb-amd64
```