### PR TITLE
Bump to alpine:3.16 docker image

### DIFF
--- a/alpine/main/Dockerfile
+++ b/alpine/main/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.16.1
+FROM alpine:3.16
 LABEL maintainer="Markus Kosmal <code@m-ko.de>"
 
 RUN apk add --no-cache bash clamav clamav-daemon clamav-libunrar


### PR DESCRIPTION
Upgrade to the latest minor release of Alpine Linux v3.16 branch